### PR TITLE
Define __slots__ for _Snode

### DIFF
--- a/suffix_trees/STree.py
+++ b/suffix_trees/STree.py
@@ -254,6 +254,8 @@ class STree():
 
 
 class _SNode():
+    __slots__ = ['_suffix_link', 'transition_links', 'idx', 'depth', 'parent', 'generalized_idxs']
+
     """Class representing a Node in the Suffix tree."""
     def __init__(self, idx=-1, parentNode=None, depth=-1):
         # Links


### PR DESCRIPTION
- Add a `__slots__` definition to the `_Snode` class. This simple optimization decreased memory usage by about 15% in my experiments.